### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,22 +6,22 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ft857d   KEYWORD1
+ft857d	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin       KEYWORD2
-check       KEYWORD2
-addCATPtt   KEYWORD2
-addCATAB    KEYWORD2
-addCATFSet  KEYWORD2
-addCATMSet  KEYWORD2
-addCATGetFreq   KEYWORD2
-addCATGetMode   KEYWORD2
-addCATSMeter    KEYWORD2
-addCATTXStatus  KEYWORD2
+begin	KEYWORD2
+check	KEYWORD2
+addCATPtt	KEYWORD2
+addCATAB	KEYWORD2
+addCATFSet	KEYWORD2
+addCATMSet	KEYWORD2
+addCATGetFreq	KEYWORD2
+addCATGetMode	KEYWORD2
+addCATSMeter	KEYWORD2
+addCATTXStatus	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords